### PR TITLE
added a suggest new username feature

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -135,7 +135,9 @@ define('forum/register', [
 				if (results.every(obj => obj.status === 'rejected')) {
 					showSuccess(usernameInput, username_notify, successIcon);
 				} else {
-					showError(usernameInput, username_notify, '[[error:username-taken]]');
+					const suggestion = username + 'suffix';
+					showError(usernameInput, username_notify, `[[error:username-taken]], try <b>${suggestion}</b>`);
+					//showError(usernameInput, username_notify, '[[error:username-taken]]');
 				}
 
 				callback();


### PR DESCRIPTION
NodeBB automatically suggests an alternative username when the chosen username is already in use. It proposes appending a suffix string to the user's original choice. For example, if a user selects test123 and it is taken, NodeBB will suggest 'test123suffix' as an alternative.