### PR TITLE
Fixed username error message

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -135,8 +135,9 @@ define('forum/register', [
 				if (results.every(obj => obj.status === 'rejected')) {
 					showSuccess(usernameInput, username_notify, successIcon);
 				} else {
-					showError(usernameInput, username_notify, '[[error:username-taken]]');
-				}
+					const suggestion = username + 'suffix';
+					showError(usernameInput, username_notify, `[[error:username-taken]] Try "${suggestion}" instead.`);
+				} 
 
 				callback();
 			});


### PR DESCRIPTION
When trying to register with a username that’s already taken, NodeBB only showed a plain error without suggesting an alternative.