### PR TITLE
fixed suggestion feature in username when duplicate exists

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -135,7 +135,8 @@ define('forum/register', [
 				if (results.every(obj => obj.status === 'rejected')) {
 					showSuccess(usernameInput, username_notify, successIcon);
 				} else {
-					showError(usernameInput, username_notify, '[[error:username-taken]]');
+					const suggestion = username + 'suffix';
+					showError(usernameInput, username_notify, `[[error:username-taken]] Try "${suggestion}" instead.`);
 				}
 
 				callback();


### PR DESCRIPTION
fixed suggestion feature in username when duplicate exists. 

added these lines
"
const suggestion = username + 'suffix';
showError(usernameInput, username_notify, `[[error:username-taken]] Try "${suggestion}" instead.`);
"

to public/src/client/register.js
					