### PR TITLE
Added suggestion name for username-taken error message

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -135,8 +135,7 @@ define('forum/register', [
 				if (results.every(obj => obj.status === 'rejected')) {
 					showSuccess(usernameInput, username_notify, successIcon);
 				} else {
-					const recommendedName = username + 'suffix';
-					showError(usernameInput, username_notify, `[[error:username-taken]]. Maybe try "${recommendedName}"`);
+					showError(usernameInput, username_notify, '[[error:username-taken]]');
 				}
 
 				callback();

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -135,7 +135,8 @@ define('forum/register', [
 				if (results.every(obj => obj.status === 'rejected')) {
 					showSuccess(usernameInput, username_notify, successIcon);
 				} else {
-					showError(usernameInput, username_notify, '[[error:username-taken]]');
+					const recommendedName = username + 'suffix';
+					showError(usernameInput, username_notify, `[[error:username-taken]]. Maybe try "${recommendedName}"`);
 				}
 
 				callback();


### PR DESCRIPTION
## Summary 
I added an improved error message for the case where a user tries to register with a username that's already taken. The message now suggests an alternative username by appending a static suffix (e.g., `username123` becomes `username123suffix`)

## Testing
Tested locally by running NodeBB and executing the updated code using these commands:
- `npm install -g grunt-cli` 
- `./nodebb build`
- `./nodebb restart`