### PR TITLE
Resolved Issue 1: Username-Taken Error

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -136,6 +136,8 @@ define('forum/register', [
 					showSuccess(usernameInput, username_notify, successIcon);
 				} else {
 					showError(usernameInput, username_notify, '[[error:username-taken]]');
+					const suggestion = username + 'suffix';
+					showError(usernameInput, username_notify, `[[error:username-taken]] Try "${suggestion}" instead.`);
 				}
 
 				callback();

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -135,7 +135,6 @@ define('forum/register', [
 				if (results.every(obj => obj.status === 'rejected')) {
 					showSuccess(usernameInput, username_notify, successIcon);
 				} else {
-					showError(usernameInput, username_notify, '[[error:username-taken]]');
 					const suggestion = username + 'suffix';
 					showError(usernameInput, username_notify, `[[error:username-taken]] Try "${suggestion}" instead.`);
 				}


### PR DESCRIPTION
Initially, when a username that is already taken is typed only this error message appears: "username taken". I resolved this issue by adding an alternative in the error message by adding a suffix to the already taken username: "username taken. Try usernamesuffix".

Closes https://github.com/CMU-17313Q/NodeBB-F25-R4/issues/1.