### PR TITLE
Resolves issue 1: when username is taken

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -135,7 +135,8 @@ define('forum/register', [
 				if (results.every(obj => obj.status === 'rejected')) {
 					showSuccess(usernameInput, username_notify, successIcon);
 				} else {
-					showError(usernameInput, username_notify, '[[error:username-taken]]');
+					const recommendedName = `${username}1`;
+					showError(usernameInput, username_notify, `[[error:username-taken]] — Try "${utils.escapeHTML(recommendedName)}"`);
 				}
 
 				callback();


### PR DESCRIPTION
1) Go to /register
2) Enter a taken username (e.g., test123)

Only shows “username taken”.

After fix
Shows “username taken — Try "<name>1"”.

