### PR TITLE
Suggesting alternative username when taken (client-side)

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -135,7 +135,9 @@ define('forum/register', [
 				if (results.every(obj => obj.status === 'rejected')) {
 					showSuccess(usernameInput, username_notify, successIcon);
 				} else {
-					showError(usernameInput, username_notify, '[[error:username-taken]]');
+					const entered = (usernameInput && usernameInput.value ? usernameInput.value : '').trim();
+					const suggestion = entered ? `${entered}suffix` : 'yourname_suffix';
+					showError(usernameInput, username_notify, `Username taken. Maybe try "${suggestion}"`);
 				}
 
 				callback();


### PR DESCRIPTION
### Summary
When a username is already taken during registration, show a friendly suggestion based on the user’s input (append `suffix`), per Issue #1.

### What changed
- **public/src/client/register.js**: replace the plain “username taken” error with:
  - read current input value
  - compute `suggestion = <entered> + "suffix"`
  - show: `Username taken. Maybe try "<suggestion>"`

### Why
Improves UX by pointing the user to an alternative immediately (as requested in the issue).

### How to test
1. Start the app and open `/register`.
2. Type a username you know is taken (e.g., `test123`).
3. Blur the field or try to submit.
4. **Expected:** inline message `Username taken. Maybe try "test123suffix"`.

### Notes
- Frontend-only, minimal change.
- No new deps, no backend changes.

Fixes #1